### PR TITLE
Add configuration for node names to support multiple control/camera/laser nodes

### DIFF
--- a/camera_control/camera_control/camera_node_client.py
+++ b/camera_control/camera_control/camera_node_client.py
@@ -6,22 +6,22 @@ from laser_control_interfaces.msg import Point
 
 # Could make a mixin if desired
 class CameraNodeClient:
-    def __init__(self, node):
+    def __init__(self, node, camera_node_name):
         node.camera_set_exposure = node.create_client(
-            SetExposure, "camera_control/set_exposure"
+            SetExposure, f"/{camera_node_name}/set_exposure"
         )
         node.camera_get_lasers = node.create_client(
-            GetPosData, "camera_control/get_laser_detection"
+            GetPosData, f"/{camera_node_name}/get_laser_detection"
         )
         node.camera_get_runners = node.create_client(
-            GetPosData, "camera_control/get_runner_detection"
+            GetPosData, f"/{camera_node_name}/get_runner_detection"
         )
         node.camera_has_frames = node.create_client(
             GetBool,
-            "camera_control/has_frames",
+            f"/{camera_node_name}/has_frames",
         )
         node.runner_point_pub = node.create_publisher(
-            Point, "camera_control/runner_point", 1
+            Point, f"/{camera_node_name}/runner_point", 1
         )
         self.node = node
 

--- a/camera_control/setup.py
+++ b/camera_control/setup.py
@@ -25,7 +25,7 @@ setup(
     tests_require=["pytest"],
     entry_points={
         "console_scripts": [
-            "camera_node = camera_control.nodes.camera_control_node:main",
+            "camera_control_node = camera_control.nodes.camera_control_node:main",
         ],
     },
 )

--- a/control_node/config/parameters.yaml
+++ b/control_node/config/parameters.yaml
@@ -1,9 +1,11 @@
-control_node:
+control0:
   ros__parameters:
+    camera_node_name: "camera0"
+    laser_node_name: "laser0"
     tracking_laser: [0.2, 0.0, 0.0]
     burn_color: [0.0, 0.0, 1.0]
     burn_time: 5
-camera_node:
+camera0:
   ros__parameters:
     video_dir: "/opt/video_stream"
     debug_video_dir: "/opt/debug_video_stream"
@@ -12,3 +14,10 @@ camera_node:
     frame_period: .1
     rgb_size: [848, 480]
     depth_size: [848, 480]
+laser0:
+  ros__parameters:
+    dac_type: "helios"
+    dac_index: 0
+    fps: 30
+    pps: 30000
+    transition_duration_ms: 0.5

--- a/control_node/launch/launch.py
+++ b/control_node/launch/launch.py
@@ -15,22 +15,22 @@ def generate_launch_description():
         [
             launch_ros.actions.Node(
                 package="camera_control",
-                executable="camera_node",
-                name="camera_node",
+                executable="camera_control_node",
+                name="camera0",
                 arguments=["--ros-args", "--log-level", "info"],
                 parameters=[parameters_file],
             ),
             launch_ros.actions.Node(
                 package="laser_control",
                 executable="laser_control_node",
-                name="laser_node",
+                name="laser0",
                 arguments=["--ros-args", "--log-level", "info"],
                 parameters=[parameters_file],
             ),
             launch_ros.actions.Node(
                 package="control_node",
                 executable="control_node",
-                name="control_node",
+                name="control0",
                 arguments=["--ros-args", "--log-level", "info"],
                 parameters=[parameters_file],
             ),

--- a/laser_control_interfaces/CMakeLists.txt
+++ b/laser_control_interfaces/CMakeLists.txt
@@ -24,12 +24,9 @@ find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
-  "msg/Dac.msg"
   "msg/Point.msg"
   "srv/AddPoint.srv"
-  "srv/ConnectToDac.srv"
   "srv/GetBounds.srv"
-  "srv/ListDacs.srv"
   "srv/SetColor.srv"
   "srv/SetPlaybackParams.srv"
   "srv/SetPoints.srv"

--- a/laser_control_interfaces/msg/Dac.msg
+++ b/laser_control_interfaces/msg/Dac.msg
@@ -1,5 +1,0 @@
-uint8 DAC_TYPE_HELIOS=0
-uint8 DAC_TYPE_ETHER_DREAM=1
-
-uint8 type
-string name

--- a/laser_control_interfaces/srv/ConnectToDac.srv
+++ b/laser_control_interfaces/srv/ConnectToDac.srv
@@ -1,3 +1,0 @@
-uint16 idx
----
-bool success

--- a/laser_control_interfaces/srv/ListDacs.srv
+++ b/laser_control_interfaces/srv/ListDacs.srv
@@ -1,2 +1,0 @@
----
-laser_control_interfaces/Dac[] dacs

--- a/rqt_laser_runner_removal/rqt_laser_runner_removal/rqt_laser_runner_removal.py
+++ b/rqt_laser_runner_removal/rqt_laser_runner_removal/rqt_laser_runner_removal.py
@@ -54,16 +54,16 @@ class RqtLaserRunnerRemoval(Plugin):
         self.show_placeholder_frames()
 
         self.state_sub = self.context.node.create_subscription(
-            String, "control_node/state", self.state_callback, 5
+            String, "/control0/state", self.state_callback, 5
         )
         self.laser_playing_sub = self.context.node.create_subscription(
-            Bool, "laser_control/playing", self.laser_playing_callback, 5
+            Bool, "/laser0/playing", self.laser_playing_callback, 5
         )
         self.color_frame_sub = self.context.node.create_subscription(
-            Image, "camera_control/color_frame", self.color_frame_callback, 1
+            Image, "/camera0/color_frame", self.color_frame_callback, 1
         )
         self.depth_frame_sub = self.context.node.create_subscription(
-            Image, "camera_control/depth_frame", self.depth_frame_callback, 1
+            Image, "/camera0/depth_frame", self.depth_frame_callback, 1
         )
 
         self.control_node_availability_timer = self.context.node.create_timer(


### PR DESCRIPTION
## Summary

This will be used to support multiple control nodes, lasers, and cameras. control_node's launch.py is set up for a single set of control/camera/laser, but in the future we can easily add a second set via this launch file.
1. Modified camera and laser nodes to relative topic and service names
2. Modified camera and laser node clients to take in a node name to prefix to service/topic names
3. Add additional configuration parameters to laser node for DAC type and index
4. Remove unnecessary ListDac, ConnectToDac, and Close services on laser node (instead, when launching the node, the DAC to connect to is specified in the parameters)

Ultimately, in the future, we'll have two sets of control/camera/laser nodes (the names of the nodes are configured in launch.py):
- control0, camera0, laser0
- control1, camera1, laser1

### Future work
- Modify camera node to support connecting to one of multiple connected RealSense cameras

## Test plan
```
colcon build
ros2 launch control_node launch.py
```

Verify that calibration process completes successfully