### PR TITLE
Use set_points service for LaserNodeClient

### DIFF
--- a/laser_control/laser_control/laser_node_client.py
+++ b/laser_control/laser_control/laser_node_client.py
@@ -58,8 +58,10 @@ class LaserNodeClient:
         rclpy.spin_until_future_complete(self.node, response)
 
     def set_point(self, point):
-        self.clear_points()
-        self.add_point(point)
+        request = SetPoints.Request()
+        request.points = [Point(x=point[0], y=point[1])]
+        response = self.node.laser_set_points.call_async(request)
+        rclpy.spin_until_future_complete(self.node, response)
 
     def clear_points(self):
         request = Empty.Request()

--- a/laser_control/laser_control/laser_node_client.py
+++ b/laser_control/laser_control/laser_node_client.py
@@ -58,8 +58,11 @@ class LaserNodeClient:
         rclpy.spin_until_future_complete(self.node, response)
 
     def set_point(self, point):
+        self.set_points([point])
+
+    def set_points(self, points):
         request = SetPoints.Request()
-        request.points = [Point(x=int(point[0]), y=int(point[1]))]
+        request.points = [Point(x=int(point[0]), y=int(point[1])) for point in points]
         response = self.node.laser_set_points.call_async(request)
         rclpy.spin_until_future_complete(self.node, response)
 

--- a/laser_control/laser_control/laser_node_client.py
+++ b/laser_control/laser_control/laser_node_client.py
@@ -59,7 +59,7 @@ class LaserNodeClient:
 
     def set_point(self, point):
         request = SetPoints.Request()
-        request.points = [Point(x=point[0], y=point[1])]
+        request.points = [Point(x=int(point[0]), y=int(point[1]))]
         response = self.node.laser_set_points.call_async(request)
         rclpy.spin_until_future_complete(self.node, response)
 

--- a/laser_control/laser_control/nodes/laser_control_node.py
+++ b/laser_control/laser_control/nodes/laser_control_node.py
@@ -105,7 +105,9 @@ class LaserControlNode(Node):
     def _get_bounds_callback(self, request, response):
         if self.dac is not None:
             points = self.dac.get_bounds(request.scale)
-            response.points = [Point(x=point[0], y=point[1]) for point in points]
+            response.points = [
+                Point(x=int(point[0]), y=int(point[1])) for point in points
+            ]
         return response
 
     def _add_point_callback(self, request, response):


### PR DESCRIPTION
LaserControlNode.set_point was making two blocking calls. We can just use the set_points service to do it in a single call.