### PR TITLE
Move points in get_centroids to be the closest point on the mask

### DIFF
--- a/ml_model/ml_model/mask_rcnn.py
+++ b/ml_model/ml_model/mask_rcnn.py
@@ -16,10 +16,10 @@ from tqdm import tqdm
 import random
 import albumentations as A
 from ml_model.model_base import ModelBase
+from ml_model.utils import find_closest_point
 from torchmetrics.detection import MeanAveragePrecision
 
 SIZE = (768, 1024)
-
 
 class AlbumRandAugment:
     def __init__(self, basic_count=0, complex_count=0):
@@ -199,8 +199,9 @@ class MaskRCNN(ModelBase):
                 y_c, x_c = np.argwhere(mask_img == 1).sum(0) / np.count_nonzero(
                     mask_img
                 )
+                closest_point = find_closest_point(mask_img, (x_c, y_c))
                 # if not np.isnan(x_c) and np.isnan()
-                point_list.append([x_c, y_c])
+                point_list.append(closest_point)
                 score_list.append(score)
 
         return score_list, point_list

--- a/ml_model/ml_model/utils.py
+++ b/ml_model/ml_model/utils.py
@@ -3,6 +3,7 @@ import glob
 import os
 import cv2
 
+from shapely.geometry import Point
 from PIL import Image
 
 
@@ -72,8 +73,20 @@ def resize_images(folder_path, output_width, output_height):
                 print(f"Skipping {filename} - Not an image.")
 
 
-# Provide the folder path containing the JPG images
-folder_path = "./ml_model/data_store/segmentation_data/images/"
-width = 960  # Change this to the desired width
-height = 720  # Change this to the desired height
-resize_images(folder_path, width, height)
+def binary_mask_to_points(binary_mask):
+    points = []
+    rows, cols = len(binary_mask), len(binary_mask[0])
+    for i in range(rows):
+        for j in range(cols):
+            if binary_mask[i][j]:
+                points.append(Point(j, i))  # Points are created with (x, y) coordinates
+    return points
+
+
+def find_closest_point(binary_mask, given_point):
+    mask_points = binary_mask_to_points(binary_mask)
+    given_point = Point(
+        given_point[1], given_point[0]
+    )  # Converting (x, y) to Point(y, x)
+    closest_point = min(mask_points, key=lambda p: given_point.distance(p))
+    return closest_point.x, closest_point.y  # Reverting

--- a/ml_model/ml_model/yolo_contours.py
+++ b/ml_model/ml_model/yolo_contours.py
@@ -2,7 +2,8 @@ import os
 import cv2
 import glob
 from ml_model.yolo import YoloBaseModel
-from shapely import Polygon
+from shapely import Polygon, Point
+from shapely.ops import nearest_points
 
 
 class YoloContours(YoloBaseModel):
@@ -13,8 +14,12 @@ class YoloContours(YoloBaseModel):
         if res[0].masks:
             for score, cords in zip(res[0].probs, res[0].masks.xy):
                 polygon = Polygon(cords)
-                point_list.append((polygon.centroid.x, polygon.centroid.y))
+                closest_polygon_point, closest_point = nearest_points(
+                    polygon, polygon.centroid
+                )
+                point_list.append((closest_polygon_point.x, closest_polygon_point.y))
                 score_list.append(score)
+
         return score_list, point_list
 
     @staticmethod


### PR DESCRIPTION
Added code to move the centroids returned by get_centroid calls to be on the point of the mask closest to the mathematical centroid. 